### PR TITLE
DP 24 changes

### DIFF
--- a/lua/weapons/arccw_cgi_k_dp24.lua
+++ b/lua/weapons/arccw_cgi_k_dp24.lua
@@ -78,10 +78,10 @@ SWEP.Firemodes = {
         Mult_RPM = 1,
     },
     {
-		Mode = 0,
+        Mode = 0,
     },
     {
-		Mode = 1,
+        Mode = 1,
         Mult_RPM = 0.3,
     },
 }


### PR DESCRIPTION
### DP24
**Added Semi Fire back
Reduced Semi RPM (246rpm)**
In semi the DPS is lower than a dc15s.
`{
        Mode = 1,
        Mult_RPM = 0.3,
    },`

**Added more delay between burst fire (0.35ms)**
In burst it is still a goated weapon.
`{
        Mode = -3,
        PostBurstDelay = 0.35,
        RunawayBurst = true,
        Mult_RPM = 1,
    },`
    
   and some indent cleanup. It's a mess here and there.